### PR TITLE
fix(ci): copy goreleaser created binary

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -2,3 +2,4 @@ golang 1.20.5
 just 1.15.0
 golangci-lint 1.46.2
 act 0.2.52
+goreleaser 1.22.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM scratch
-COPY ./dist/bank-downloaders /opt/app/
+COPY ./bankdownloader /opt/app/
 WORKDIR /opt/app
 ENTRYPOINT ["/opt/app/bank-downloaders"]

--- a/justfile
+++ b/justfile
@@ -1,10 +1,15 @@
 BINARY_NAME := "bankdownloader"
+export REGISTRY := "ghcr.io"
+export IMAGE_NAME := "airtonix/bankdownloader"
 
 dev *ARGS:
   go run . {{ARGS}}
 
 build: 
-  go build -o dist/
+  goreleaser build --snapshot --clean
+
+release:
+  goreleaser release --clean --skip-publish --snapshot --rm-dist
 
 test:
   for PACKAGE in $(go list ./...); do go test -v ${PACKAGE}; done;


### PR DESCRIPTION
# Description

When creating docker images, there's a binary that goreleaser will create before running the docker build step.

This just changes to assuming we're copy one from the `./dist` directory to the one that go releaser creates.


## What kind of change is this?

- [x] bug fix
- [ ] documentation
- [ ] new feature

## Steps to test changes

Run a local release without publishing

```
just release
```