### PR TITLE
fix: dont override content permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,8 @@ on:
 permissions:
   contents: write
   pull-requests: write
-
+  packages: write
+  
 name: Release Management
 
 jobs:
@@ -33,10 +34,6 @@ jobs:
 
     runs-on: ubuntu-22.04
     needs: [Release]
-
-    permissions:
-      contents: read
-      packages: write
 
     env:
       REGISTRY: ghcr.io


### PR DESCRIPTION
# Description

incorrectly overode the `permissions: content: write` permission

## What kind of change is this?

- [x] bug fix
- [ ] documentation
- [ ] new feature
